### PR TITLE
Update to rescue eth/erc20 ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hacker Houses Streams
+# LaunchPod Streams
 
 This **forkable** project aims to provide a platform to retroactively fund open-source work by providing a monthly 
 UBI to handpicked open-source developers, rewarding them for their ongoing contributions.


### PR DESCRIPTION
-Separate modals for eth rescue and erc20 rescue to be flexible for all possible scenarios (i.e., in eth mode, but erc20 needs to be rescued). Rescue modals now also show balance that can be rescued.
-Updated reset button so it does not appear where no reset is necessary (ie., rescue eth)

