### PR TITLE
Update to rescue functions ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LaunchPod Streams
+# Hacker Houses Streams
 
 This **forkable** project aims to provide a platform to retroactively fund open-source work by providing a monthly 
 UBI to handpicked open-source developers, rewarding them for their ongoing contributions.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hacker Houses Streams
+# LaunchPod Streams
 
 This **forkable** project aims to provide a platform to retroactively fund open-source work by providing a monthly 
 UBI to handpicked open-source developers, rewarding them for their ongoing contributions.

--- a/packages/nextjs/components/Admin.tsx
+++ b/packages/nextjs/components/Admin.tsx
@@ -445,7 +445,7 @@ const Admin = () => {
             <div>
               {isErc20 && (
                 <div>
-                  The contract has a current token balance of:{" "}
+                  The contract has a current token balance of:
                   {contractTokenBalanceData && contractTokenBalanceData.toString()}
                 </div>
               )}
@@ -454,7 +454,9 @@ const Admin = () => {
                 Token Address:
               </label>
               <AddressInput
-                value={rescueToken === "0x0000000000000000000000000000000000000000" ? "" : rescueToken}
+                value={
+                  rescueToken.toString() === "0x0000000000000000000000000000000000000000" ? "" : rescueToken.toString()
+                }
                 onChange={value => setRescueToken(value)}
               />
             </div>

--- a/packages/nextjs/components/Admin.tsx
+++ b/packages/nextjs/components/Admin.tsx
@@ -325,6 +325,7 @@ const Admin = () => {
                   <option value="update">Update Creator</option>
                   <option value="remove">Remove Creator</option>
                   <option value="fund">Fund Contract</option>
+                  <option value="drain">Drain Agreement</option>
                   <option value="addadmin">Add Admin</option>
                   <option value="removeadmin">Remove Admin</option>
                   <option value="rescueToken">Rescue Tokens</option>
@@ -376,12 +377,6 @@ const Admin = () => {
                 Cap:
               </label>
               <EtherInput value={cap.toString()} onChange={value => setCap(value)} placeholder="Enter cap amount" />
-            </div>
-          )}
-
-          {modalAction === "rescueeth" && (
-            <div>
-              The contract has a current eth balance of: <Balance address={streamContract.data?.address} />
             </div>
           )}
 

--- a/packages/nextjs/components/Admin.tsx
+++ b/packages/nextjs/components/Admin.tsx
@@ -455,7 +455,7 @@ const Admin = () => {
               </label>
               <AddressInput
                 value={
-                  rescueToken.toString() === "0x0000000000000000000000000000000000000000" ? "" : rescueToken.toString()
+                  rescueToken === "0x0000000000000000000000000000000000000000" ? "" : rescueToken
                 }
                 onChange={value => setRescueToken(value)}
               />


### PR DESCRIPTION
-Separate modals for eth rescue and erc20 rescue to be flexible for all possible scenarios (i.e., in eth mode, but erc20 needs to be rescued). Rescue modals now also show balance that can be rescued.
-Updated reset button so it does not appear where no reset is necessary (ie., rescue eth)