### PR TITLE
Resolved 'no hacker stream' display before loading completes and removed modals' z-index

### DIFF
--- a/packages/nextjs/components/homepage/AdminModal.tsx
+++ b/packages/nextjs/components/homepage/AdminModal.tsx
@@ -334,7 +334,7 @@ export const AdminModal = ({
 
   return (
     <div className="">
-      <div className="fixed inset-0 flex items-center justify-center bg-gray-900 bg-opacity-50 z-20 md:text-base text-[0.8rem]">
+      <div className="fixed inset-0 flex items-center justify-center bg-gray-900 bg-opacity-50  md:text-base text-[0.8rem]">
         <div className=" modal-box">
           <label onClick={closePopup} className="btn btn-sm btn-circle absolute right-2 top-2">
             ✕

--- a/packages/nextjs/components/homepage/Contributions.tsx
+++ b/packages/nextjs/components/homepage/Contributions.tsx
@@ -27,16 +27,20 @@ const Contributions = ({ creatorPage }: { creatorPage: boolean }) => {
     eventName: "Withdrawn",
     listener: logs => {
       logs.map(log => {
-        const [creator, amount, reason] = log.args;
+        const creator = log.args[0];
+        const amount = log.args[1];
+        const reason = log.args[2];
         const newEvent = { args: [creator, amount, reason], block: { timestamp: Math.floor(Date.now() / 1000) } };
-        const currentEvents = withdrawnEvents;
-        currentEvents?.push(newEvent);
-        setWithdrawnEvents(currentEvents);
+        setWithdrawnEvents(prev => {
+          if (prev) {
+            const updatedEvents = [newEvent, ...prev];
+            return updatedEvents;
+          }
+          return [newEvent];
+        });
       });
     },
   });
-
-  // console.log(withdrawnEvents);
 
   const getDate = (timestamp: number) => {
     const date = new Date(Number(timestamp) * 1000);

--- a/packages/nextjs/components/homepage/StreamData.tsx
+++ b/packages/nextjs/components/homepage/StreamData.tsx
@@ -127,9 +127,10 @@ const StreamData = ({ creatorPage }: { creatorPage: boolean }) => {
                   </div>
                 </div>
               ))}
-            {!isLoadingCreators && !isSettingCreatorsData && Object.keys(creatorsData).length === 0 && (
-              <div className="text-center py-6">No Hacker Streams</div>
-            )}
+            {!isLoadingCreators &&
+              !isSettingCreatorsData &&
+              creators.length === 0 &&
+              Object.keys(creatorsData).length === 0 && <div className="text-center py-6">No Hacker Streams</div>}
             {!isLoadingCreators &&
               Object.entries(creatorsData).map(([creatorAddress, creatorData]) => (
                 <HackersInfoDisplay key={creatorAddress} creatorData={creatorData} creatorAddress={creatorAddress} />

--- a/packages/nextjs/components/homepage/StreamData.tsx
+++ b/packages/nextjs/components/homepage/StreamData.tsx
@@ -30,6 +30,7 @@ const StreamData = ({ creatorPage }: { creatorPage: boolean }) => {
   const [creatorsData, setCreatorsData] = useState<CreatorData>({});
   const [adminToRemove, setAdminToRemove] = useState("");
   const [uniqueAdmins, setUniqueAdmins] = useState<string[]>([]);
+  const [isSettingCreatorsData, setIsSettingCreatorsData] = useState(true);
   const { address } = useAccount();
 
   const { isCreator } = useIsCreator();
@@ -58,7 +59,12 @@ const StreamData = ({ creatorPage }: { creatorPage: boolean }) => {
     args: [creatorPage ? [address || ""] : creators],
   });
 
-  useSetCreator({ allCreatorsData, creators: creatorPage ? [address || ""] : creators, setCreatorsData });
+  useSetCreator({
+    allCreatorsData,
+    creators: creatorPage ? [address || ""] : creators,
+    setCreatorsData,
+    setIsSettingCreatorsData,
+  });
 
   const { isErc20, isEns, isOp } = useErc20();
   const [modalOpen, setModalOpen] = useState(false);
@@ -109,7 +115,7 @@ const StreamData = ({ creatorPage }: { creatorPage: boolean }) => {
           </div>
 
           <div>
-            {isLoadingCreators &&
+            {isSettingCreatorsData &&
               Array.from({ length: creatorPage ? 1 : 3 }).map((_, index) => (
                 <div key={index} className="animate-pulse flex justify-between px-6 py-4">
                   <div className="rounded-md bg-slate-300 h-6 w-[5%]"></div>
@@ -121,7 +127,7 @@ const StreamData = ({ creatorPage }: { creatorPage: boolean }) => {
                   </div>
                 </div>
               ))}
-            {!isLoadingCreators && Object.keys(creatorsData).length === 0 && (
+            {!isLoadingCreators && !isSettingCreatorsData && Object.keys(creatorsData).length === 0 && (
               <div className="text-center py-6">No Hacker Streams</div>
             )}
             {!isLoadingCreators &&

--- a/packages/nextjs/components/homepage/WithdrawModal.tsx
+++ b/packages/nextjs/components/homepage/WithdrawModal.tsx
@@ -70,7 +70,7 @@ export const WithdrawModal = ({
   return (
     <div className="">
       {isOpen && (
-        <div className="fixed inset-0 flex items-center justify-center bg-gray-900 bg-opacity-50 z-20 md:text-sm text-[0.7rem]">
+        <div className="fixed inset-0 flex items-center justify-center bg-gray-900 bg-opacity-50 md:text-sm text-[0.7rem]">
           <div className=" modal-box">
             <label onClick={closePopup} className="btn btn-sm btn-circle absolute right-2 top-2">
               ✕

--- a/packages/nextjs/components/homepage/WithdrawModal.tsx
+++ b/packages/nextjs/components/homepage/WithdrawModal.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useState } from "react";
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
 import { EtherInput } from "../scaffold-eth";
 import { parseEther } from "viem";
 import { useScaffoldContractWrite } from "~~/hooks/scaffold-eth";
@@ -13,6 +13,8 @@ export const WithdrawModal = ({
   const [reason, setReason] = useState("");
   const [amount, setAmount] = useState("0");
   const characterLimit = 400;
+
+  const labelRef = useRef<HTMLLabelElement | null>(null);
 
   const { writeAsync: withdraw } = useScaffoldContractWrite({
     contractName: "YourContract",
@@ -32,30 +34,68 @@ export const WithdrawModal = ({
     } else return;
   };
 
+  useEffect(() => {
+    const handleEscapeKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closePopup();
+      }
+    };
+
+    const handleOverlayClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+
+      if (target.classList.contains("bg-gray-900")) {
+        closePopup();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleEscapeKey);
+      document.addEventListener("mousedown", handleOverlayClick);
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleEscapeKey);
+      document.removeEventListener("mousedown", handleOverlayClick);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (labelRef.current) {
+      labelRef.current.focus();
+    }
+  }, []);
+
   return (
-    <div className="border-2 rounded-xl overflow-hidden border-black w-fit text-xs bg-base-200 h-full">
+    <div className="">
       {isOpen && (
         <div className="fixed inset-0 flex items-center justify-center bg-gray-900 bg-opacity-50 z-20 md:text-sm text-[0.7rem]">
           <div className=" modal-box">
             <label onClick={closePopup} className="btn btn-sm btn-circle absolute right-2 top-2">
               ✕
             </label>
-            <label className="block mt-4 mb-2">Amount:</label>
-            <EtherInput
-              value={amount.toString()}
-              onChange={value => {
-                setAmount(value);
-              }}
-              placeholder="Enter withdraw amount"
-            />
-            <label className="block mt-2 mb-2">Reason:</label>
+            <label ref={labelRef}>
+              <h1 className="block mt-4 mb-2">Amount: </h1>
+              <EtherInput
+                value={amount.toString()}
+                onChange={value => {
+                  setAmount(value);
+                }}
+                placeholder="Enter withdraw amount"
+              />
+            </label>
 
-            <textarea
-              className="textarea textarea-bordered  focus:bg-transparent focus:text-gray-500 h-[2.2rem] min-h-[6.2rem] px-4  w-full font-medium placeholder:text-accent/50 text-gray-500 rounded-lg"
-              placeholder={`Enter Reason (limit: ${characterLimit} characters)`}
-              value={reason}
-              onChange={e => handleReasonChange(e.target.value)}
-            ></textarea>
+            <label>
+              <h1 className="block mt-2 mb-2">Reason:</h1>
+              <textarea
+                className="textarea textarea-bordered  focus:bg-transparent focus:text-gray-500 h-[2.2rem] min-h-[6.2rem] px-4  w-full font-medium placeholder:text-accent/50 text-gray-500 rounded-lg"
+                placeholder={`Enter Reason (limit: ${characterLimit} characters)`}
+                value={reason}
+                onChange={e => handleReasonChange(e.target.value)}
+              ></textarea>
+            </label>
+
             <p className="font-sans italic font-normal -mt-1">Remaining characters: {characterLimit - reason.length}</p>
             <button className="btn btn-primary rounded-lg w-full mt-2 ml-auto" onClick={() => withdraw()}>
               Withdraw

--- a/packages/nextjs/hooks/useFetchCreators.ts
+++ b/packages/nextjs/hooks/useFetchCreators.ts
@@ -4,7 +4,7 @@ import { useDeployedContractInfo, useScaffoldEventHistory, useScaffoldEventSubsc
 
 export const useFetchCreators = () => {
   const [creators, setCreators] = useState<string[]>([]);
-  const [isValidatingCreators, setIsValidatingCreators] = useState(false);
+  const [isValidatingCreators, setIsValidatingCreators] = useState(true);
 
   // Read the creatorAdded events to get added creators.
   const {
@@ -27,7 +27,6 @@ export const useFetchCreators = () => {
       logs.map(log => {
         const creator = log.args[0];
         setCreators(prev => [...prev, creator] as string[]);
-        console.log(log);
       });
     },
   });

--- a/packages/nextjs/hooks/useIsCreator.ts
+++ b/packages/nextjs/hooks/useIsCreator.ts
@@ -24,7 +24,7 @@ export function useIsCreator() {
   }
 
   return {
-    isCreator: !address || creator == address,
+    isCreator: creator == address,
     isLoading: false,
   };
 }

--- a/packages/nextjs/hooks/useSetCreator.ts
+++ b/packages/nextjs/hooks/useSetCreator.ts
@@ -7,9 +7,10 @@ type Props = {
   allCreatorsData: any;
   creators: string[];
   setCreatorsData: any;
+  setIsSettingCreatorsData: any;
 };
 
-export function useSetCreator({ allCreatorsData, creators, setCreatorsData }: Props) {
+export function useSetCreator({ allCreatorsData, creators, setCreatorsData, setIsSettingCreatorsData }: Props) {
   const [creatorData, setCreatorData] = useState<CreatorData>({});
   if (Array.isArray(allCreatorsData) && creators.length > 0) {
     const renewedData: CreatorData = {};
@@ -34,8 +35,13 @@ export function useSetCreator({ allCreatorsData, creators, setCreatorsData }: Pr
   useEffect(() => {
     if (creators.length == 0) {
       setCreatorsData({});
+      setTimeout(() => {
+        setIsSettingCreatorsData(false);
+      }, 5000);
     } else {
       setCreatorsData(creatorData);
+      setIsSettingCreatorsData(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setCreatorsData, creatorData, creators]);
 }

--- a/packages/nextjs/hooks/useTokenBalance.ts
+++ b/packages/nextjs/hooks/useTokenBalance.ts
@@ -37,6 +37,14 @@ export const useTokenBalance = ({ address, isEns, isOp }: TTokenBalanceHookProps
     },
   });
 
+  useScaffoldEventSubscriber({
+    contractName: "YourContract",
+    eventName: "Withdrawn",
+    listener: () => {
+      setUpdataBalance(true);
+    },
+  });
+
   useEffect(() => {
     (async () => {
       if (tokenAddress && tokenAddress != "0x0000000000000000000000000000000000000000" && address) {

--- a/packages/nextjs/pages/creator.tsx
+++ b/packages/nextjs/pages/creator.tsx
@@ -16,7 +16,7 @@ const Creator: React.FC<undefined> = () => {
   }
 
   return (
-    <div className="flex flex-col gap-4 xs:w-4/5 xl:w-1/2 w-11/12">
+    <div className="flex flex-col gap-4 xs:w-4/5 lg:max-w-5xl w-11/12">
       {isLoadingCreators ? (
         <div className="flex flex-col gap-4">
           <div className="flex animate-pulse gap-2">

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -8,7 +8,7 @@ const Home: NextPage = () => {
   return (
     <>
       <MetaHeader />
-      <div className="flex flex-col gap-4 xs:w-4/5 xl:w-[60%] w-11/12">
+      <div className="flex flex-col gap-4 xs:w-4/5 lg:max-w-5xl w-11/12">
         <Welcome />
         <StreamData creatorPage={false} />
 


### PR DESCRIPTION
- I've introduced a 5-second delay before returning the "No hacker stream message" to ensure that there are no creators. Please note that it might take longer to set the complete data, especially for streams with a lot of creators, but a 5 sec wait is reasonable for fetching the basic info.

- When I start a new frontend session, I tend to forget to grap eth from the faucet before opening the modals to perform transactions. So, I have to close the modal windows and grab faucet before reopening which can be annoying if i already filled the data in. So i removed the z-index